### PR TITLE
Improve search timing and open logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Start an interactive research session. The agent issues Search/Open/Find/Crawl/R
 python main.py research "what is the tallest building in Europe"
 ```
 
+The agent prints a short snippet whenever it opens a page, so you can
+verify that the requested URL was actually fetched.
+
 ### crawl
 Pre-crawl a domain so results are immediately available for Recall.
 


### PR DESCRIPTION
## Summary
- execute model-requested `Open` actions right after a `Search`
- print a snippet when opening pages so it's clear the URL was fetched
- document the new open behaviour in `README.md`

## Testing
- `python -m py_compile agent.py`

------
https://chatgpt.com/codex/tasks/task_e_686541515d248323b6db11384e76e69e